### PR TITLE
Fix path when loading librato.coffee

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -2,7 +2,7 @@ fs = require 'fs'
 path = require 'path'
 
 module.exports = (robot, scripts) ->
-  scriptsPath = path.resolve(__dirname, 'src', 'scripts')
+  scriptsPath = path.resolve(__dirname, 'src')
   fs.exists scriptsPath, (exists) ->
     if exists
       for script in fs.readdirSync(scriptsPath)


### PR DESCRIPTION
`librato.coffee` lives in `src`, not in `src/scripts`.
