### PR TITLE
Sources can contain special characters

### DIFF
--- a/src/librato.coffee
+++ b/src/librato.coffee
@@ -106,7 +106,7 @@ processIntrumentResponse = (body, source, msg, timePeriod, robot) ->
     getGraphForIntrument(json['instruments'][0], source, msg, timePeriod, robot)
 
 module.exports = (robot) ->
-  robot.respond /graph me ([\w ]+?)\s*(?:over the (?:last|past)? )?(\d+ (?:second|minute|hour|day|week)s?)?(?: source ({\w|\*}+))?$/i, (msg) ->
+  robot.respond /graph me ([\w ]+?)\s*(?:over the (?:last|past)? )?(\d+ (?:second|minute|hour|day|week)s?)?(?: source (.+))?$/i, (msg) ->
     instrument = msg.match[1]
     timePeriod = msg.match[2] || 'hour'
     source = msg.match[3] || '*'


### PR DESCRIPTION
Right now this doesn't support a source such as `api-production*`.  This PR fixes that.
